### PR TITLE
Feature/RFC: Remote Ohai Info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,13 +3,21 @@
 # Created by https://www.toptal.com/developers/gitignore/api/visualstudiocode,macos,ruby
 # Edit at https://www.toptal.com/developers/gitignore?templates=visualstudiocode,macos,ruby
 
+
+# Functional and Unit test data
+
+*.swp
+attestations.*
+**.lock
+test_hdf.json
+
 ### macOS ###
 # General
 .DS_Store
 .AppleDouble
 .LSOverride
 
-# Icon must end with two \r
+# Icon must end with two 
 Icon
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,9 @@
 PATH
   remote: .
   specs:
-    inspec-reporter-json-hdf (1.1.1.7.gbd15e2d.1.dirty.20220306.175639)
+    inspec-reporter-json-hdf (1.1.1.8.g1312bfc.1.dirty.20220306.210617)
       git-version-bump
+      ohai
       ruh-roo (~> 3.0.1)
 
 GEM
@@ -312,6 +313,8 @@ GEM
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
     ffi (1.15.5)
+    ffi-yajl (2.4.0)
+      libyajl2 (>= 1.2)
     fuzzyurl (0.9.0)
     git-version-bump (0.17.1)
     google-api-client (0.52.0)
@@ -374,9 +377,11 @@ GEM
       train-core (~> 3.0)
       tty-prompt (~> 0.17)
       tty-table (~> 0.10)
+    ipaddress (0.8.3)
     jmespath (1.6.0)
     json (2.6.1)
     jwt (2.3.0)
+    libyajl2 (2.1.0)
     license-acceptance (2.1.13)
       pastel (~> 0.7)
       tomlrb (>= 1.2, < 3.0)
@@ -389,13 +394,13 @@ GEM
     memoist (0.16.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.0)
     minitest (5.15.0)
     minitest-reporters (1.5.0)
       ansi
       builder
       minitest (>= 5.0)
       ruby-progressbar
+    mixlib-cli (2.1.8)
     mixlib-config (3.0.9)
       tomlrb
     mixlib-log (3.0.9)
@@ -417,10 +422,22 @@ GEM
     net-scp (3.0.0)
       net-ssh (>= 2.6.5, < 7.0.0)
     net-ssh (6.1.0)
-    nokogiri (1.13.3)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.13.3-arm64-darwin)
       racc (~> 1.4)
     nori (2.6.0)
+    ohai (17.9.0)
+      chef-config (>= 14.12, < 18)
+      chef-utils (>= 16.0, < 18)
+      ffi (~> 1.9)
+      ffi-yajl (~> 2.2)
+      ipaddress
+      mixlib-cli (>= 1.7.0)
+      mixlib-config (>= 2.0, < 4.0)
+      mixlib-log (>= 2.0.1, < 4.0)
+      mixlib-shellout (~> 3.2, >= 3.2.5)
+      plist (~> 3.1)
+      train-core
+      wmi-lite (~> 1.0)
     os (1.1.4)
     parallel (1.21.0)
     parser (3.1.1.0)
@@ -428,6 +445,7 @@ GEM
     parslet (1.8.2)
     pastel (0.8.0)
       tty-color (~> 0.5)
+    plist (3.6.0)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -644,6 +662,7 @@ GEM
       rubyzip (~> 2.0)
       winrm (~> 2.0)
     wisper (2.0.1)
+    wmi-lite (1.0.5)
 
 PLATFORMS
   ruby

--- a/inspec-reporter-json-hdf.gemspec
+++ b/inspec-reporter-json-hdf.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'ruh-roo', '~> 3.0.1'
   spec.add_runtime_dependency 'git-version-bump'
+  spec.add_runtime_dependency 'ohai'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'bundler-audit'

--- a/lib/inspec-reporter-json-hdf/reporter.rb
+++ b/lib/inspec-reporter-json-hdf/reporter.rb
@@ -2,6 +2,8 @@
 require 'inspec/plugin/v2'
 require 'json'
 require 'roo'
+require 'pry'
+require "ohai" unless defined?(Ohai::System)
 
 VALID_FREQUENCY = %w[annually semiannually quarterly monthly every2weeks weekly every3days daily].freeze
 
@@ -14,6 +16,55 @@ SUPPORTED_INCLUDE_TYPES = %w[csv xlsx].freeze
 module InspecPlugins::HdfReporter
   # Reporter Plugin Class
   class Reporter < Inspec.plugin(2, :reporter)
+    
+    # references
+    # https://github.com/chef/ohai/pull/1503/files
+    # https://github.com/chef/chef/blob/7558c414030d082194d0d2b5f74279ce151517e9/lib/chef/client.rb#L574-L609
+    # 
+    # binding.pry
+    
+    # #
+    # # Populate the minimal ohai attributes defined in #run_ohai with data train collects.
+    # #
+    # # Eventually ohai may support colleciton of data.
+    # #
+    # def get_ohai_data_remotely
+    #   ohai.data[:fqdn] = if transport_connection.respond_to?(:hostname)
+    #                        transport_connection.hostname
+    #                      else
+    #                        Chef::Config[:target_mode][:host]
+    #                      end
+    #   if transport_connection.respond_to?(:os)
+    #     ohai.data[:platform] = transport_connection.os.name
+    #     ohai.data[:platform_version] = transport_connection.os.release
+    #     ohai.data[:os] = transport_connection.os.family_hierarchy[1]
+    #     ohai.data[:platform_family] = transport_connection.os.family
+    #   end
+    #   # train does not collect these specifically
+    #   # ohai.data[:machinename] = nil
+    #   # ohai.data[:hostname] = nil
+    #   # ohai.data[:os_version] = nil # kernel version
+
+    #   ohai.data[:ohai_time] = Time.now.to_f
+    #   events.ohai_completed(node)
+    # end
+
+    # #
+    # # Run ohai plugins.  Runs all ohai plugins unless minimal_ohai is specified.
+    # #
+    # # Sends the ohai_completed event when finished.
+    # #
+    # # @see Chef::EventDispatcher#
+    # # @see Chef::Config#minimal_ohai
+    # #
+    # # @api private
+    # #
+    # def run_ohai
+    #   filter = Chef::Config[:minimal_ohai] ? %w{fqdn machinename hostname platform platform_version ohai_time os os_version init_package} : nil
+    #   ohai.all_plugins(filter)
+    #   events.ohai_completed(node)
+    # end
+
     def render
       output(report.to_json, false)
     end


### PR DESCRIPTION
## General Goal

Enhance our reporter plugin and add a new core plugin to inspec that will use the new Ohai remote target mode and the existing train connection to the target to populate  a new section of the [`run_data`](https://github.com/inspec/inspec/blob/main/dev-docs/plugins.md#the-run_data-structure) in inspec which will support adding a top-level `.target` object in the [JSON base reporter](https://github.com/inspec/inspec/blob/main/lib/inspec/reporters/json.rb) to collect inventory information about the asset under test.

### References

- https://github.com/inspec/inspec/blob/main/dev-docs/plugins.md
- https://github.com/chef/ohai/pull/1503 
- https://github.com/chef/chef/blob/7558c414030d082194d0d2b5f74279ce151517e9/lib/chef/client.rb#L574-L609 

## Approach

[Notes from Conversation with @cwolf on topic](../wiki/OHAI-Remote-Targeting-Current-State)

### This PR should be split into two parts.

1. A PR on the https://github.com/mitre/inspec/tree/remote-ohai branch for adding things to core
2. A simple PR here to update the reporter and adjust the logic of this reporter to account for not using the `attestation` function and just having the new ohai data

_Follow On Work_

3. Determin if we should update other core plugins as part of (1) or if they should be follow-on PRs
4. Propose Idea on InSpec project to finish the `make all reporters plugins`, add a `cli-options` plug-in type, etc.

#### Part (1)
- A core plug-in addition to inspec-core, that will use a remote ohai connection ( as the chef-infra client does above with a little hacking ) via the existing transport and update the `run_data` object for use in other reporters. 
- Add two cli flags to thor `--without-ohai` and `--ohai-plugins=<list>` to over-ride the default filters. 
- Make a default dataset that ohai collects that is close to the core data collected via the `automate` reporter
- Adds in target specific environment ohai plugins - ec2, docker, etc. where it is applicable if train can tell us we are on an ec2, docker, etc.
- Add a new toplevel json object to the base `json reporter` called `target` that holds the new data.

#### Part (2)
- Either 
  (a) Update the hdf reporter to use the new `run_data` from ohai and its `target-specific` data
   (b) Merge the hdf reporter into core as an Attestation PR next to waiver and update our technical implemation to follow closely with waiver

This approach would allow us to know which transport we are using and then – if a specific Ohai plugin exists for that target – ec2, vmware, docker etc. – we could active it and pass the information about through to the final report.

#### Part (3) 
- Perhaps update the automate reporter to also consume this data
- perhaps update the cli reporter to display a few useful details from this new data 

#### (Part 4) Longer Tearm Solution

A `cli-options plugin` type would be the best way to approach this however, @cwolf said things are a bit of mess at the moment so this is likely the only real viable approach at the moment.

Then the HDF reporter or any reporter could just check for the existance of the OHAI data in the `run_data` object and layer it in if it is there.

## Questions / Workflow

- ***[answered here](../wiki/OHAI-Remote-Targeting-Current-State)*** how can I run it 'via bundle' aka locally so I don't have to hack code, rebuild plugin gem, uninstall, install, run again and at the reporter phase, 
- ***[answered here](../wiki/OHAI-Remote-Targeting-Current-State)*** - Is is arealdy dead by this time it seems - Is the Train connection already gone at the 'reporter' phase or can I use some form of the Chef client code above to layer a specific Ohio data subset that I want in my final report.

Signed-off-by: Aaron Lippold <lippold@gmail.com>